### PR TITLE
POM: Use properties to manage versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>http://forum.image.sc/</archive>
 		</mailingList>
 	</mailingLists>
 
@@ -58,6 +58,17 @@
 		<license.projectName>N5 Viewer</license.projectName>
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Igor Pisarev, Stephan Saalfeld</license.copyrightOwners>
+		
+		<bigdataviewer_fiji.version>6.0.0</bigdataviewer_fiji.version>
+		<bigdataviewer-core.version>7.0.0</bigdataviewer-core.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-15</bigdataviewer-vistools.version>
+
+		<n5.version>2.1.1</n5.version>
+		<n5-aws-s3.version>2.1.0</n5-aws-s3.version>
+		<n5-google-cloud.version>2.3.1</n5-google-cloud.version>
+		<n5-imglib2.version>3.4.1</n5-imglib2.version>
+
+		<jackson-databind.version>2.9.8</jackson-databind.version>
 	</properties>
 
 	<developers>
@@ -96,12 +107,10 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer_fiji</artifactId>
-			<version>6.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-core</artifactId>
-			<version>7.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
@@ -114,12 +123,12 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5</artifactId>
-			<version>2.1.1</version>
+			<version>${n5.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-aws-s3</artifactId>
-			<version>2.1.0</version>
+			<version>${n5-aws-s3.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>
@@ -130,7 +139,7 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-google-cloud</artifactId>
-			<version>2.3.1</version>
+			<version>${n5-google-cloud.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>
@@ -141,24 +150,23 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-imglib2</artifactId>
-			<version>3.4.1</version>
+			<version>${n5-imglib2.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-vistools</artifactId>
-			<version>1.0.0-beta-15</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.9.8</version>
+			<version>${jackson-databind.version}</version>
 		</dependency>
 	</dependencies>
 
 	<repositories>
 		<repository>
-			<id>imagej.public</id>
-			<url>https://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 		<repository>
 			<id>saalfeld-lab-maven-repo</id>


### PR DESCRIPTION
This allows for overriding the version properties when using SciJava tooling to build several components with the same dependency versions.

Other changes:
* Update forum URL
* Update maven repository URL
* Remove <version> tags for those components managed by pom-scijava (overriding the version property is sufficient in these cases)