### PR TITLE
Update the POM

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<https://www.gnu.org/licenses/>.
+<http://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.1.0</version>
+		<version>32.0.0</version>
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>
@@ -97,14 +97,6 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<n5.version>2.5.1</n5.version>
-		<n5-aws-s3.version>3.2.0</n5-aws-s3.version>
-		<n5-google-cloud.version>3.3.2</n5-google-cloud.version>
-		<n5-hdf5.version>1.3.0</n5-hdf5.version>
-		<n5-ij.version>3.2.0</n5-ij.version>
-		<n5-imglib2.version>4.3.0</n5-imglib2.version>
-		<n5-zarr.version>0.0.7</n5-zarr.version>
-
 		<alphanumeric-comparator.version>1.4.1</alphanumeric-comparator.version>
 	</properties>
 
@@ -144,7 +136,6 @@
 		<dependency>
 			<groupId>org.janelia.saalfeldlab</groupId>
 			<artifactId>n5-ij</artifactId>
-			<version>${n5-ij.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>se.sawano.java</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
 		<license.projectName>N5 Viewer</license.projectName>
 		<license.organizationName>Saalfeld Lab</license.organizationName>
 		<license.copyrightOwners>Igor Pisarev, Stephan Saalfeld</license.copyrightOwners>
+		<license.excludes>**/resources/**</license.excludes>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/ColorGenerator.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/ColorGenerator.java
@@ -1,18 +1,23 @@
-/**
- * License: GPL
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License 2
- * as published by the Free Software Foundation.
- *
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
  */
 package org.janelia.saalfeldlab.n5.bdv;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/CropController.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/CropController.java
@@ -1,18 +1,23 @@
-/**
- * License: GPL
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License 2
- * as published by the Free Software Foundation.
- *
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
  */
 package org.janelia.saalfeldlab.n5.bdv;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/MultiscaleDatasets.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/MultiscaleDatasets.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.bdv;
 
 import java.io.IOException;

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Source.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Source.java
@@ -1,18 +1,23 @@
-/**
- * License: GPL
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License 2
- * as published by the Free Software Foundation.
- *
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
  */
 package org.janelia.saalfeldlab.n5.bdv;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Viewer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Viewer.java
@@ -1,18 +1,23 @@
-/**
- * License: GPL
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License 2
- * as published by the Free Software Foundation.
- *
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
  */
 package org.janelia.saalfeldlab.n5.bdv;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5ViewerTreeCellRenderer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5ViewerTreeCellRenderer.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.bdv;
 
 import java.awt.Component;

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5VolatileSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5VolatileSource.java
@@ -1,18 +1,23 @@
-/**
- * License: GPL
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License 2
- * as published by the Free Software Foundation.
- *
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
  */
 package org.janelia.saalfeldlab.n5.bdv;
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/metadata/MetadataMipmapSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/metadata/MetadataMipmapSource.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.metadata;
 
 import java.io.IOException;

--- a/src/main/java/org/janelia/saalfeldlab/n5/metadata/MetadataSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/metadata/MetadataSource.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.metadata;
 
 import java.io.IOException;

--- a/src/main/java/org/janelia/saalfeldlab/n5/metadata/MetadataSources.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/metadata/MetadataSources.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.metadata;
 
 import java.util.ArrayList;

--- a/src/main/java/org/janelia/saalfeldlab/n5/metadata/N5ViewerDatasetFilter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/metadata/N5ViewerDatasetFilter.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.metadata;
 
 import java.util.function.Predicate;

--- a/src/main/java/org/janelia/saalfeldlab/n5/metadata/N5ViewerMultichannelMetadata.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/metadata/N5ViewerMultichannelMetadata.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.metadata;
 
 import java.util.Arrays;

--- a/src/test/java/org/janelia/saalfeldlab/n5/bdv/BdvAxisMetadataTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/bdv/BdvAxisMetadataTest.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.bdv;
 
 import static org.junit.Assert.*;

--- a/src/test/java/org/janelia/saalfeldlab/n5/bdv/MultiscaleSortTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/bdv/MultiscaleSortTest.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.bdv;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/src/test/java/org/janelia/saalfeldlab/n5/bdv/N5SourceFromMetadataTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/bdv/N5SourceFromMetadataTest.java
@@ -1,3 +1,24 @@
+/*-
+ * #%L
+ * N5 Viewer
+ * %%
+ * Copyright (C) 2017 - 2022 Igor Pisarev, Stephan Saalfeld
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
 package org.janelia.saalfeldlab.n5.bdv;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
This patch updates the parent to the latest release (32.0.0), which fixes a dependency issue where xml-apis is excluded and creates a runtime problem with Java 8 (`java.lang.NoClassDefFoundError: org/w3c/dom/ElementTraversal`).
