### PR TITLE
Change bdv.util.volatiles.SharedQueue to bdv.cache.SharedQueue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>31.1.0</version>
+		<version>33.2.0</version>
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Source.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Source.java
@@ -17,7 +17,7 @@
 package org.janelia.saalfeldlab.n5.bdv;
 
 import bdv.util.AbstractSource;
-import bdv.util.volatiles.SharedQueue;
+import bdv.cache.SharedQueue;
 import bdv.util.volatiles.VolatileTypeMatcher;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.RandomAccessibleInterval;

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Viewer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5Viewer.java
@@ -24,7 +24,7 @@ import bdv.tools.brightness.ConverterSetup;
 import bdv.tools.brightness.RealARGBColorConverterSetup;
 import bdv.tools.transformation.TransformedSource;
 import bdv.util.*;
-import bdv.util.volatiles.SharedQueue;
+import bdv.cache.SharedQueue;
 import bdv.viewer.DisplayMode;
 import bdv.viewer.Source;
 import bdv.viewer.SourceAndConverter;

--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5VolatileSource.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5VolatileSource.java
@@ -17,7 +17,7 @@
 package org.janelia.saalfeldlab.n5.bdv;
 
 import bdv.util.AbstractSource;
-import bdv.util.volatiles.SharedQueue;
+import bdv.cache.SharedQueue;
 import bdv.util.volatiles.VolatileViews;
 import mpicbg.spim.data.sequence.VoxelDimensions;
 import net.imglib2.RandomAccessibleInterval;


### PR DESCRIPTION
The n5-viewer in FIJI currently crashes with the following error when trying to open a dataset.

```
Exception in thread "AWT-EventQueue-0" java.lang.NoSuchMethodError: bdv.util.volatiles.VolatileViews.wrapAsVolatile(Lnet/imglib2/RandomAccessibleInterval;Lbdv/util/volatiles/SharedQueue;Lnet/imglib2/cache/volatiles/CacheHints;)Lnet/imglib2/RandomAccessibleInterval;
    at org.janelia.saalfeldlab.n5.bdv.N5VolatileSource.getSource(N5VolatileSource.java:59)
    at org.janelia.saalfeldlab.n5.bdv.N5Viewer.addSourceToListsRealType(N5Viewer.java:388)
    at org.janelia.saalfeldlab.n5.bdv.N5Viewer.addSourceToListsGenericType(N5Viewer.java:356)
    at org.janelia.saalfeldlab.n5.bdv.N5Viewer.buildN5Sources(N5Viewer.java:298)
    at org.janelia.saalfeldlab.n5.bdv.N5Viewer.exec(N5Viewer.java:182)
    at org.janelia.saalfeldlab.n5.bdv.N5Viewer.lambda$run$2(N5Viewer.java:138)
    at org.janelia.saalfeldlab.n5.ui.DatasetSelectorDialog.ok(DatasetSelectorDialog.java:718)
    at org.janelia.saalfeldlab.n5.ui.DatasetSelectorDialog.lambda$run$5(DatasetSelectorDialog.java:314)
```

This is due to https://github.com/bigdataviewer/bigdataviewer-vistools/commit/01fe2d2bb18c6905ef3a7297cd12bf421cc97262 from https://github.com/bigdataviewer/bigdataviewer-vistools/pull/56 .

The solution is change deprecated references of `bdv.util.volatiles.SharedQueue` to `bdv.cache.SharedQueue`