### PR TITLE
Add alternative runWithDialog() method

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5ViewerCreator.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/bdv/N5ViewerCreator.java
@@ -165,6 +165,19 @@ public class N5ViewerCreator {
 		}
 	}
 
+	public void runWithDialog( final String pathToContainer )
+	{
+		runWithDialog( pathToContainer, Throwable::printStackTrace );
+	}
+
+	public void runWithDialog( final String pathToContainer, final Consumer< Exception > exceptionHandler )
+	{
+		lastOpenedContainer = pathToContainer;
+		dialog = null;
+		openViewer( exceptionHandler );
+		dialog.openContainer( pathToContainer );
+	}
+
 	private void selectTreeItem(final List<String> itemPath) {
 
 		final JTree t = dialog.getJTree();


### PR DESCRIPTION
This pull request adds overloaded `runWithDialog` methods to the `N5ViewerCreator` class.

This allows to reproduce the state, which is reached after pressing "browse" in the selection dialog.
Contributes so solve: https://github.com/saalfeldlab/n5-viewer/issues/49

The main changes are:

* Added a new `runWithDialog(String pathToContainer, Consumer<Exception> exceptionHandler)`.
* Added a new `runWithDialog(String pathToContainer)` method, which defaults to printing exceptions.
